### PR TITLE
cmsis_6: Integrate with zephyr build system

### DIFF
--- a/CMSIS/CMakeLists.txt
+++ b/CMSIS/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(Core)

--- a/CMSIS/Core/CMakeLists.txt
+++ b/CMSIS/Core/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(Include)
+
+# As of CMSIS v5.6.0, __PROGRAM_START is to indicate whether the
+# ARM vendor or the OS supplies data/bss init routine, otherwise
+# the default data/bss init routine for the selected toolchain is
+# added. We set the macro in build-time to guarantee compatibility
+# with all existing ARM platforms.
+
+zephyr_compile_definitions(__PROGRAM_START)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(CMSIS)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake-ext: true
+  kconfig-ext: true


### PR DESCRIPTION
Add the cmsis_5 build system to cmsis_6
Someone more knowledgable then me needs to check this.

PS: IAR has a CRITICAL bug in CMSIS 5.9.0 so to be able to support zephyr (coming shortly) we really really need CMSIS_6 or backport the fix into CMSIS 5.9.0.

Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/84330