### PR TITLE
cmsis_6: Integrate with zephyr build system

### DIFF
--- a/CMSIS/CMakeLists.txt
+++ b/CMSIS/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory_ifdef(CONFIG_HAS_CMSIS_CORE_M Core)

--- a/CMSIS/Core/CMakeLists.txt
+++ b/CMSIS/Core/CMakeLists.txt
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_include_directories(Include)
+
+# As of CMSIS v5.6.0, __PROGRAM_START is to indicate whether the
+# ARM vendor or the OS supplies data/bss init routine, otherwise
+# the default data/bss init routine for the selected toolchain is
+# added. We set the macro in build-time to guarantee compatibility
+# with all existing ARM platforms.
+
+zephyr_compile_definitions(__PROGRAM_START)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(CMSIS)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake-ext: true
+  kconfig-ext: true


### PR DESCRIPTION
ARM has deprecated 5.9.0 and we will need to start using CMSIS_6 to get upstream features and continue supporting tf-m. This commit will integrate it just like CMSIS_5.

Zephyr PR testing this : https://github.com/zephyrproject-rtos/zephyr/pull/89370