### PR TITLE
m-profile: Support picolibc startup mechanism

### DIFF
--- a/CMSIS/Core/Include/m-profile/cmsis_gcc_m.h
+++ b/CMSIS/Core/Include/m-profile/cmsis_gcc_m.h
@@ -29,6 +29,10 @@
 
 #include <arm_acle.h>
 
+#if defined(__PICOLIBC__) && !defined(__PROGRAM_START)
+#define __PROGRAM_START _start
+#endif
+
 /* #########################  Startup and Lowlevel Init  ######################## */
 #ifndef __PROGRAM_START
 


### PR DESCRIPTION
We don't need to use __cmsis_start when using picolibc; we can call main directly.